### PR TITLE
Shutdown function accepts immutable self reference

### DIFF
--- a/windivert/src/divert/mod.rs
+++ b/windivert/src/divert/mod.rs
@@ -378,7 +378,7 @@ impl<L: layer::WinDivertLayerTrait> WinDivert<L> {
     }
 
     /// Shutdown function.
-    pub fn shutdown(&mut self, mode: WinDivertShutdownMode) -> Result<(), WinDivertError> {
+    pub fn shutdown(&self, mode: WinDivertShutdownMode) -> Result<(), WinDivertError> {
         Ok(unsafe { BOOL(sys::WinDivertShutdown(self.handle.0, mode)) }.ok()?)
     }
 }


### PR DESCRIPTION
Shutdown function accepts an immutable reference to WinDivert object (as it was apparently intended).