### PR TITLE
feat(windivert-sys): refactor path handling with path_macro2 and improve build scripts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: [1.64]
+        msrv: [1.68]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/windivert-sys/Cargo.toml
+++ b/windivert-sys/Cargo.toml
@@ -28,12 +28,10 @@ thiserror = "1"
 
 [dependencies.windows]
 version = "0.48"
-features = [
-    "Win32_Foundation",
-    "Win32_System_IO",
-]
+features = ["Win32_Foundation", "Win32_System_IO"]
 
 [build-dependencies]
+path_macro2 = "0.1.3"
 cc = "1.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
## Description
This PR addresses critical CI build failures and enhances path handling robustness for cross-platform compatibility. Below are the details of the issues encountered and the corresponding solutions implemented.

### Issues Encountered in CI Build
1. **Missing `vendor` Directory**: The `vendor` directory (containing third-party dependencies) was absent in the target path during CI runs. This caused failures when the `static` feature is enabled (requires dependency source/binary files from the vendor submodule).
2. **Incorrect Path Resolution**: When building the GNU version of the WinDivert static library in CI, `build.rs` failed to locate the `vendor/dll` directory. The root cause was a hardcoded Windows-style path string (`"vendor\include"`), which is incompatible with cross-platform build environments.

---

### Relevant modification measures:
- Replace hardcoded string paths with `path_macro2` macros to improve cross-platform compatibility and maintainability.
- Add `path_macro2` as a build dependency in `Cargo.toml`.
- Implement automatic Git submodule initialization for static builds.
- Optimize the file copying logic and sys file detection in the build script.
- Consistently use the `path!` and `path_const!` macros to format paths in the compiler configurations (gnu.rs and msvc.rs), thereby generating path formats compatible with the respective systems.

Could you please review this PR when you have time? Let me know if there are any adjustments needed for better compatibility or maintainability!