### PR TITLE
feat: expose raw HANDLE for FFI interop (e.g. WinDivertShutdown from another thread)

### DIFF
--- a/windivert/src/divert/mod.rs
+++ b/windivert/src/divert/mod.rs
@@ -111,6 +111,21 @@ impl<L: layer::WinDivertLayerTrait> WinDivert<L> {
         }
         Ok(())
     }
+
+    /// Returns the underlying raw WinDivert `HANDLE`.
+    ///
+    /// This is intended for FFI interop scenarios where the raw handle must be
+    /// passed to Windows API functions from another thread — for example,
+    /// calling `WinDivertShutdown` to unblock a `recv` call that is blocked on
+    /// a different thread.
+    ///
+    /// # Safety contract
+    ///
+    /// The caller must ensure that the `WinDivert` instance outlives any use of
+    /// the returned handle.  The handle must not be closed by the caller.
+    pub fn as_raw_handle(&self) -> HANDLE {
+        self.handle
+    }
 }
 
 impl WinDivert<layer::NetworkLayer> {


### PR DESCRIPTION
## Problem

There is currently no way to obtain the underlying `HANDLE` from a `WinDivert<L>` instance in safe code. This forces consumers who need cross-thread shutdown (calling `WinDivertShutdown` from a thread other than the one blocked in `recv`) to either:

- cast internal struct layout with `unsafe` pointer arithmetic (fragile, breaks silently on any crate change), or
- keep a second handle open just for shutdown signalling.

## Solution

Add `as_raw_handle(&self) -> HANDLE` to the generic `impl<L> WinDivert<L>` block.

```rust
/// Returns the underlying raw WinDivert `HANDLE`.
///
/// Intended for FFI interop scenarios where the raw handle must be
/// passed to Windows API functions from another thread — for example,
/// calling `WinDivertShutdown` to unblock a `recv` call that is blocked
/// on a different thread.
pub fn as_raw_handle(&self) -> HANDLE {
    self.handle
}
```

## Usage example

```rust
// Thread A — blocked on recv
let wd = WinDivert::network("true", 0, WinDivertFlags::new())?;
let raw = wd.as_raw_handle();

// Thread B — signal shutdown
std::thread::spawn(move || {
    unsafe { WinDivertShutdown(raw, WinDivertShutdownMode::Both) };
});
```

## Notes

- The method is on the generic `impl<L>` block so it is available for all layer types.
- No `unsafe` on the method itself; the doc comment documents the caller's responsibility (lifetime, no manual close).
- This is a non-breaking additive change.