### PR TITLE
Bump windows to 0.62 and thiserror to 2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.68"]
+        msrv: ["1.81"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.81"]
+        msrv: ["1.82"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/windivert-sys/Cargo.toml
+++ b/windivert-sys/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["external-ffi-bindings"]
 readme = "../README.md"
 license = "LGPL-3.0-or-later"
 edition = "2021"
-rust-version = "1.81"
+rust-version = "1.82"
 links = "WinDivert"
 build = "build/main.rs"
 

--- a/windivert-sys/Cargo.toml
+++ b/windivert-sys/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["external-ffi-bindings"]
 readme = "../README.md"
 license = "LGPL-3.0-or-later"
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.81"
 links = "WinDivert"
 build = "build/main.rs"
 
@@ -24,10 +24,10 @@ vendored = []
 static = ["vendored"]
 
 [dependencies]
-thiserror = "1"
+thiserror = "2"
 
 [dependencies.windows]
-version = "0.48"
+version = "0.62"
 features = [
     "Win32_Foundation",
     "Win32_System_IO",

--- a/windivert-sys/src/bindings/mod.rs
+++ b/windivert-sys/src/bindings/mod.rs
@@ -15,8 +15,9 @@ pub use error::*;
 mod newtypes;
 pub use newtypes::*;
 
+use windows::core::BOOL;
 use windows::Win32::{
-    Foundation::{BOOL, HANDLE},
+    Foundation::HANDLE,
     System::IO::OVERLAPPED,
 };
 /// Default value for queue length parameter.

--- a/windivert/Cargo.toml
+++ b/windivert/Cargo.toml
@@ -18,11 +18,11 @@ static = ["vendored", "windivert-sys/static"]
 
 [dependencies]
 etherparse = "0.13"
-thiserror = "1"
+thiserror = "2"
 windivert-sys = { version = "0.10.0", path = "../windivert-sys" }
 
 [dependencies.windows]
-version = "0.48"
+version = "0.62"
 features = [
 	"Devices_Custom",
 	"Win32_Devices",

--- a/windivert/src/divert/mod.rs
+++ b/windivert/src/divert/mod.rs
@@ -33,6 +33,11 @@ pub struct WinDivert<L: layer::WinDivertLayerTrait> {
     _layer: PhantomData<L>,
 }
 
+// SAFETY: HANDLE contains a *mut c_void (as of windows 0.58+) but represents
+// a Win32 kernel handle which is safe to send and share across threads.
+unsafe impl<L: layer::WinDivertLayerTrait> Send for WinDivert<L> {}
+unsafe impl<L: layer::WinDivertLayerTrait> Sync for WinDivert<L> {}
+
 /// Recv implementations
 impl<L: layer::WinDivertLayerTrait> WinDivert<L> {
     /// Open a handle using the specified parameters.

--- a/windivert/src/divert/mod.rs
+++ b/windivert/src/divert/mod.rs
@@ -18,7 +18,7 @@ use windows::{
         System::{
             Services::{
                 CloseServiceHandle, ControlService, OpenSCManagerA, OpenServiceA,
-                SC_MANAGER_ALL_ACCESS, SERVICE_CONTROL_STOP, SERVICE_STATUS,
+                SC_MANAGER_ALL_ACCESS, SERVICE_CONTROL_STOP,
             },
             Threading::{CreateEventA, TlsAlloc, TlsGetValue, TlsSetValue},
         },
@@ -60,10 +60,10 @@ impl<L: layer::WinDivertLayerTrait> WinDivert<L> {
     pub(crate) fn _get_event(tls_idx: u32) -> Result<HANDLE, WinDivertError> {
         let mut event = HANDLE::default();
         unsafe {
-            event.0 = TlsGetValue(tls_idx) as isize;
+            event.0 = TlsGetValue(tls_idx);
             if event.is_invalid() {
                 event = CreateEventA(None, false, false, None)?;
-                TlsSetValue(tls_idx, Some(event.0 as *mut c_void));
+                TlsSetValue(tls_idx, Some(event.0 as *const c_void))?;
             }
         }
         Ok(event)
@@ -189,26 +189,18 @@ impl WinDivert<()> {
 
     /// Method that tries to uninstall WinDivert driver.
     pub fn uninstall() -> WinResult<()> {
-        let status: *mut SERVICE_STATUS = MaybeUninit::uninit().as_mut_ptr();
+        let mut status = MaybeUninit::uninit();
         unsafe {
+            let status = status.as_mut_ptr();
             let manager = OpenSCManagerA(None, None, SC_MANAGER_ALL_ACCESS)?;
             let service = OpenServiceA(
                 manager,
                 PCSTR::from_raw("WinDivert".as_ptr()),
                 SC_MANAGER_ALL_ACCESS,
             )?;
-            let res = ControlService(service, SERVICE_CONTROL_STOP, status);
-            if !res.as_bool() {
-                return Err(WinError::from(GetLastError()));
-            }
-            let res = CloseServiceHandle(service);
-            if !res.as_bool() {
-                return Err(WinError::from(GetLastError()));
-            }
-            let res = CloseServiceHandle(manager);
-            if !res.as_bool() {
-                return Err(WinError::from(GetLastError()));
-            }
+            ControlService(service, SERVICE_CONTROL_STOP, status)?;
+            CloseServiceHandle(service)?;
+            CloseServiceHandle(manager)?;
         }
         Ok(())
     }

--- a/windivert/src/packet.rs
+++ b/windivert/src/packet.rs
@@ -41,7 +41,7 @@ impl<'a> WinDivertPacket<'a, layer::NetworkLayer> {
                 )
             };
             if !res.as_bool() {
-                return Err(WinDivertError::from(windows::core::Error::from_win32()));
+                return Err(WinDivertError::from(windows::core::Error::from_thread()));
             }
         }
         Ok(())
@@ -72,7 +72,7 @@ impl<'a> WinDivertPacket<'a, layer::ForwardLayer> {
                 )
             };
             if !res.as_bool() {
-                return Err(WinDivertError::from(windows::core::Error::from_win32()));
+                return Err(WinDivertError::from(windows::core::Error::from_thread()));
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary
- Bump `windows` crate from 0.48 to 0.62 in both `windivert-sys` and `windivert`
- Bump `thiserror` from 1 to 2 in both crates
- Adapt to all breaking API changes (`BOOL` moved to `windows::core`, `HANDLE.0` is now `*mut c_void`, several Win32 functions now return `Result<()>`, `Error::from_win32()` replaced by `Error::from_thread()`)
- Fix pre-existing dangling pointer in `uninstall()` `MaybeUninit` usage
- Bump MSRV to 1.81 (required by `thiserror` 2)

## Test plan
- [x] `cargo check --features vendored` compiles cleanly with no warnings
- [x] `cargo check --features static` compiles cleanly
- [x] `cargo test --features vendored` passes
- [ ] CI passes on windows-latest with msvc and gnu toolchains

🤖 Generated with [Claude Code](https://claude.com/claude-code)