### PR TITLE
Fix issues on WinDivert::uninstall()

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.68"]
+        msrv: ["1.71"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/windivert-sys/Cargo.toml
+++ b/windivert-sys/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["external-ffi-bindings"]
 readme = "../README.md"
 license = "LGPL-3.0-or-later"
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.71"
 links = "WinDivert"
 build = "build/main.rs"
 

--- a/windivert/src/divert/mod.rs
+++ b/windivert/src/divert/mod.rs
@@ -189,7 +189,7 @@ impl WinDivert<()> {
 
     /// Method that tries to uninstall WinDivert driver.
     pub fn uninstall() -> WinResult<()> {
-        let status: *mut SERVICE_STATUS = MaybeUninit::uninit().as_mut_ptr();
+        let mut status = MaybeUninit::<SERVICE_STATUS>::uninit();
         unsafe {
             let manager = OpenSCManagerA(None, None, SC_MANAGER_ALL_ACCESS)?;
             let service = OpenServiceA(
@@ -197,7 +197,7 @@ impl WinDivert<()> {
                 PCSTR::from_raw("WinDivert".as_ptr()),
                 SC_MANAGER_ALL_ACCESS,
             )?;
-            let res = ControlService(service, SERVICE_CONTROL_STOP, status);
+            let res = ControlService(service, SERVICE_CONTROL_STOP, status.as_mut_ptr());
             if !res.as_bool() {
                 return Err(WinError::from(GetLastError()));
             }

--- a/windivert/src/divert/mod.rs
+++ b/windivert/src/divert/mod.rs
@@ -194,7 +194,7 @@ impl WinDivert<()> {
             let manager = OpenSCManagerA(None, None, SC_MANAGER_ALL_ACCESS)?;
             let service = OpenServiceA(
                 manager,
-                PCSTR::from_raw("WinDivert".as_ptr()),
+                PCSTR::from_raw("WinDivert\0".as_ptr()),
                 SC_MANAGER_ALL_ACCESS,
             )?;
             let res = ControlService(service, SERVICE_CONTROL_STOP, status.as_mut_ptr());


### PR DESCRIPTION
This fixes two issues in WinDivert::uninstall():
1. MaybeUninit::uninit().as_mut_ptr() produces a dangling pointer. The temporary is dropped at the end of the statement, so ControlService() writes through freed stack memory (UB).
2. The service name passed to OpenServiceA() is a Rust &str without a NUL terminator.

Note: (2) overlaps with #29. It was authored on Jul 13 (see AuthorDate) in https://github.com/dilluti0n/dpibreak/commit/82c8d8097c6e239a59bd7fa7011366a43ac1c649, before #29 was opened. I'm upstreaming them together since they touch the same function. Happy to rebase and drop the second commit if #29 is merged first.