### PR TITLE
Relax shutdown() receiver to &self

### DIFF
--- a/windivert/src/divert/mod.rs
+++ b/windivert/src/divert/mod.rs
@@ -104,7 +104,7 @@ impl<L: layer::WinDivertLayerTrait> WinDivert<L> {
     }
 
     /// Shutdown function.
-    pub fn shutdown(&mut self, mode: WinDivertShutdownMode) -> WinResult<()> {
+    pub fn shutdown(&self, mode: WinDivertShutdownMode) -> WinResult<()> {
         let res = unsafe { sys::WinDivertShutdown(self.handle, mode) };
         if !res.as_bool() {
             return Err(WinError::from(unsafe { GetLastError() }));


### PR DESCRIPTION
Unblocking WinDivertRecv() from another thread is in fact the whole purpose of WinDivertShutdown(), but &mut self made that impossible on a shared (Arc) handle. It only reads self.handle and doesn't invalidate it, so &self is sound.

Downstream usage: https://github.com/dilluti0n/dpibreak/blob/e14866ca04ad2909c456411c301cb8a9434c2473/src/platform/windows.rs#L42-L48
```rust
fn shutdown_all() {
    for h in RECV_HANDLES.lock().expect("mutex poisoned").iter() {
        if let Err(e) = h.shutdown(WinDivertShutdownMode::Both) {
            crate::warn!("windivert: shutdown: {e}");
        }
    }
}
```