### PR TITLE
Delegate set_loopback method in address wrapper

### DIFF
--- a/windivert/src/address.rs
+++ b/windivert/src/address.rs
@@ -65,6 +65,12 @@ impl<L: layer::WinDivertLayerTrait> WinDivertAddress<L> {
         self.data.loopback()
     }
 
+    /// Loopback setter
+    #[inline]
+    pub fn set_loopback(&mut self, value: bool) {
+        self.data.set_loopback(value)
+    }
+
     ///  Set to `true` for impostor packets, `false` otherwise.
     #[inline]
     pub fn impostor(&self) -> bool {


### PR DESCRIPTION
Not sure why some fields don't have their setters delegated, and it seems like `loopback` needs to be set manually when redirecting outbound traffic to localhost (i.e. setting `packet.data` with updated headers doesn't automatically update `loopback`).